### PR TITLE
Add bedrock to sky islands plains

### DIFF
--- a/default/biomes/plains_sky.yml
+++ b/default/biomes/plains_sky.yml
@@ -3,6 +3,12 @@ id: "SKY_ISLANDS"
 color: 0xff0000
 noise-equation: "if(max(y-96, 0), -(if(max(y-150, 0), |y-150|, |y-150|/16)) - 0.25 + (noise2(x*3, z*3)*3), ((-((y / base)^2)) + 1) + |(noise2(x, z) / 3) + 0.1|)"
 palette:
+  - "BLOCK:minecraft:bedrock": 0
+  - BEDROCK_MOST: 1
+  - BEDROCK_HALF: 2
+  - BEDROCK_LITTLE: 3
+  - RIVER_BOTTOM: 61
+  - RIVER_SHORE: 62
   - GRASSY: 255
 vanilla: PLAINS
 


### PR DESCRIPTION
# Pull Request

## Brief description.
Sky islands don't have bedrock, so I added it.

### What Issues Does This Fix?
Fix #37 

## Licensing

- [x] I am the original author of this code, and I am willing to release it under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
- [ ] I am not the original author of this code, but it is in public domain or released under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) or a compatible license.

## Goal of the PR

- [x] Add bedrock to sky plains

## Affects of the PR

<!---
    What types of changes does your code introduce? (Select any that apply. You may select multiple.)
    You must put an x in all the boxes that it applies to. (Like this: [x])
-->
#### Types of changes

- [x] Bug fix <!-- Anything which fixes an issue in Terra. -->
- [ ] New feature <!-- Anything which adds new functionality to Terra. -->

#### Compatiblity

- [ ] Breaking change <!-- A fix, or a feature, that breaks some previous functionality to Terra. -->
- [x] Non-Breaking change.
    <!--
        A change which does not break *any* previous functionality of Terra.
        (ie. is backwards compatible and will work with *any* previously existing supported features.
        Note: if a feature is annotated with @Incubating, @Preview, @Experimental,
        or is in a package called something similar to the previous annotations,
        then you may push breaking changes to only THOSE parts of Terra.)
    -->

#### Contribution Guidelines.

- [x] I have read the [`CONTRIBUTING.md`](https://github.com/PolyhedralDev/Terra/blob/master/CONTRIBUTING.md) document in the root of the git repository.
- [x] My code follows the code style for this project. <!-- There is an included `.editorconfig` file in the base of the repo. Please use a plugin for your IDE of choice that follows those settings. -->

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
