### PR TITLE
Fix inconsistencies with frozen ocean biomes.

### DIFF
--- a/default/biomes/mountain/mountains_stone.yml
+++ b/default/biomes/mountain/mountains_stone.yml
@@ -3,7 +3,7 @@ id: "MOUNTAINS_STONE"
 noise-equation: "((-((y / base)^2)) + 1) + |((noise2(x, z)+0.5) / 3)| + max(noise2(x/2, z/2)*4 + noise2(x*8, z*8)*0.25, 0)"
 prevent-smooth: true
 ocean:
-  palette: COLD_OCEAN
+  palette: FROZEN_OCEAN
 palette:
   - "BLOCK:minecraft:bedrock": 0
   - BEDROCK_MOST: 1

--- a/default/biomes/ocean/ocean_frozen.yml
+++ b/default/biomes/ocean/ocean_frozen.yml
@@ -1,6 +1,6 @@
 extends: "OCEAN_ABSTRACT"
 id: "FROZEN_OCEAN"
-vanilla: COLD_OCEAN
+vanilla: FROZEN_OCEAN
 color: 0x7070d6
 palette:
   - "BLOCK:minecraft:bedrock": 0
@@ -10,7 +10,7 @@ palette:
   - TUNDRA: 255
   - OCEANFLOOR: 60
 ocean:
-  palette: "COLD_OCEAN"
+  palette: "FROZEN_OCEAN"
   level: 62
 tags:
   - "OCEAN"

--- a/default/biomes/ocean_deep/ocean_frozen.yml
+++ b/default/biomes/ocean_deep/ocean_frozen.yml
@@ -1,6 +1,6 @@
 extends: "DEEP_OCEAN_ABSTRACT"
 id: "FROZEN_OCEAN_DEEP"
-vanilla: COLD_OCEAN
+vanilla: FROZEN_OCEAN
 color: 0x404090
 palette:
   - "BLOCK:minecraft:bedrock": 0
@@ -10,7 +10,7 @@ palette:
   - TUNDRA: 255
   - OCEANFLOOR: 60
 ocean:
-  palette: "COLD_OCEAN"
+  palette: "FROZEN_OCEAN"
   level: 62
 tags:
   - "OCEAN"

--- a/default/biomes/rivers/river_mtn.yml
+++ b/default/biomes/rivers/river_mtn.yml
@@ -17,7 +17,7 @@ vanilla: MOUNTAINS
 blend:
   distance: 1
 ocean:
-  palette: COLD_OCEAN
+  palette: FROZEN_OCEAN
 flora:
   - density: 10
     items:

--- a/default/palettes/frozen_ocean.yml
+++ b/default/palettes/frozen_ocean.yml
@@ -5,4 +5,4 @@ layers:
   - materials:
       - "minecraft:water": 1
     layers: 1
-id: "COLD_OCEAN"
+id: "FROZEN_OCEAN"


### PR DESCRIPTION
Fixes frozen oceans and deep variant not using correct vanilla biome, as well as changing cold ocean palette name to reflect frozen oceans and changing any references to the cold ocean palette to frozen ocean. Only default pack has been touched.