### PR TITLE
Plains flora changes + Sunflower plains addition.

### DIFF
--- a/default/biomes/plains.yml
+++ b/default/biomes/plains.yml
@@ -31,7 +31,14 @@ flora:
     items:
       - TALL_GRASS: 150
       - GRASS: 700
-      - SUNFLOWER: 20
+      - DANDELION: 1
+      - OXEYE_DAISY: 1
+      - CORNFLOWER: 1
+      - AZURE_BLUET: 1
+      - RED_TULIP: 1
+      - ORANGE_TULIP: 1
+      - WHITE_TULIP: 1
+      - PINK_TULIP: 1
 trees:
   - density: 0.02
     items:

--- a/default/biomes/plains_sky.yml
+++ b/default/biomes/plains_sky.yml
@@ -22,7 +22,14 @@ flora:
     items:
       - TALL_GRASS: 150
       - GRASS: 700
-      - SUNFLOWER: 20
+      - DANDELION: 1
+      - OXEYE_DAISY: 1
+      - CORNFLOWER: 1
+      - AZURE_BLUET: 1
+      - RED_TULIP: 1
+      - ORANGE_TULIP: 1
+      - WHITE_TULIP: 1
+      - PINK_TULIP: 1
 trees:
   - density: 0.02
     items:

--- a/default/biomes/plains_sunflower.yml
+++ b/default/biomes/plains_sunflower.yml
@@ -1,0 +1,50 @@
+extends: "PLAINS_ABSTRACT"
+id: "SUNFLOWER_PLAINS"
+color: 0xe8De2a
+palette:
+  - "BLOCK:minecraft:bedrock": 0
+  - BEDROCK_MOST: 1
+  - BEDROCK_HALF: 2
+  - BEDROCK_LITTLE: 3
+  - RIVER_BOTTOM: 61
+  - RIVER_SHORE: 62
+  - GRASSY: 255
+biome-noise:
+  type: OpenSimplex2
+  frequency: 0.01
+vanilla: SUNFLOWER_PLAINS
+tags:
+  - "LAND"
+  - "RIVER_ERODE"
+structures:
+  - VILLAGE_PLAINS
+  - STRONGHOLD
+  - OUTPOST
+  - DUNGEON
+  - MINESHAFT
+
+flora:
+  - density: 50
+    y:
+      min: 62
+      max: 84
+    items:
+      - TALL_GRASS: 150
+      - GRASS: 700
+      - SUNFLOWER: 20
+      - DANDELION: 5
+      - OXEYE_DAISY: 1
+      - CORNFLOWER: 1
+      - AZURE_BLUET: 1
+      - RED_TULIP: 1
+      - ORANGE_TULIP: 1
+      - WHITE_TULIP: 1
+      - PINK_TULIP: 1
+
+trees:
+  - density: 0.02
+    items:
+      - PUMPKIN_PATCH: 1
+    y:
+      min: 58
+      max: 92

--- a/default/pack.yml
+++ b/default/pack.yml
@@ -219,6 +219,7 @@ biomes:
             - PLAINS: 24
             - SKY_ISLANDS: 1
             - DARK_FOREST: 8
+            - SUNFLOWER_PLAINS: 6
             - CRAG: 4
             - MOUNTAINS_PRETTY: 6
           noise: *biome-distribute


### PR DESCRIPTION
Correction of issues in #50.
This PR adds a new sunflower plains biome (essentially the old plains biome), as well as changing the regular plains biome flora (as well as sky islands) to be more in line with vanilla population.
![2021-05-20_01 07 37](https://user-images.githubusercontent.com/82296481/119194576-4b195200-ba51-11eb-8fa5-b3009cac4ec9.png)
![2021-05-20_01 06 56](https://user-images.githubusercontent.com/82296481/119194585-4eacd900-ba51-11eb-90a4-f56db0d4d427.png)

