### PR TITLE
Commenting taiga buffer zone

### DIFF
--- a/default/pack.yml
+++ b/default/pack.yml
@@ -148,7 +148,7 @@ biomes:
           from: "BIOME:PLAINS"
           to:
             - TUNDRA: 4 # Super cold biomes
-            - TAIGA: 2 # Taiga buffer zone
+            # - TAIGA: 2  Taiga buffer zone
             - PLAINS: 8 # Temperate biomes
             - JUNGLE: 12 # Warm biomes
           noise: *climate # Use climate noise


### PR DESCRIPTION
Taiga buffer zone is not replaced afterward during the pipeline while tundra, plains and jungle are replaced with other biomes. This make the world unbalanced with too much taiga biomes.